### PR TITLE
Fix JST task to generate template functions that accept arguments.

### DIFF
--- a/build/tasks/jst/jst.js
+++ b/build/tasks/jst/jst.js
@@ -66,6 +66,7 @@ task.registerHelper("jst", function(files, namespace, templateSettings) {
 
         "return ",
         underscoreTemplating(file.read(filepath)).replace("anonymous", ""),
+        "(data, _)",
 
       "};"].join("");
 


### PR DESCRIPTION
With this fix the JST function more closely/correctly follows the function generated by underscore. I verified it works at least for me.
