### PR TITLE
if protocol isn't part of url, it is relative

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -95,10 +95,9 @@ jQuery(function($) {
   $(document).on("click", "a:not([data-bypass])", function(evt) {
     // Get the anchor href and protcol
     var href = $(this).attr("href");
-    var protocol = this.protocol + "//";
 
     // Ensure the protocol is not part of URL, meaning its relative.
-    if (href.indexOf(protocol) < 0) {
+    if (url.match("^(ftp|http|https):+.") == null) {
       // Stop the default event to ensure the link will not cause a page
       // refresh.
       evt.preventDefault();


### PR DESCRIPTION
Right now if the href is not relative, i.e http://example.com/login  it will try to navigate to http://example.com/http://example.com/login...   The navigation should only happen if it is relative, meaning no protocol is provided.

This should probably be switched to checking for any protocol  <anything>://  to prevent from capturing links to external websites for itunes links as well.
