### PR TITLE
Do not route to relative URLs that are javascript snippets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -111,6 +111,11 @@ jQuery(function($) {
       // refresh.
       evt.preventDefault();
 
+      // Make sure that we navigate to a URL that does not include a
+      // leading front slash because that's not what the router expects
+      // but that's what we want to do in our HTML.
+      href = href.replace(/^\//, "");
+
       // This uses the default router defined above, and not any routers
       // that may be placed in modules.  To have this work globally (at the
       // cost of losing all route events) you can change the following line


### PR DESCRIPTION
This is something I encountered while using a jQuery plugin that generates anchor tags like this `<a href="javascript:void(0)">Cancel</a>`. As it's hard to go in and modify the plugin, I preferred to handle it in my backbone code. I think it might be a good default behavior and may be useful to others to, it is to your discretion if you think it is generic enough or not to be merged in.
