### PR TITLE
Change build source paths for app, templates & css to include files in subdirectories

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -18,14 +18,14 @@ config.init({
     ],
 
     // Application files
-    "dist/debug/js/app.js": ["app/namespace.js", "app/modules/*.js", "app/index.js"],
+    "dist/debug/js/app.js": ["app/namespace.js", "app/modules/**/*.js", "app/index.js"],
 
     // Your CSS
-    "dist/debug/css/style.css": ["assets/css/*.css"]
+    "dist/debug/css/style.css": ["assets/css/**/*.css"]
   },
-  
+
   jst: {
-    "dist/debug/js/templates.js": ["app/templates/*.html"]
+    "dist/debug/js/templates.js": ["app/templates/**/*.html"]
   },
 
   min: {


### PR DESCRIPTION
Changed source paths from, for example:
`["app/templates/*.html"]`
to:
`["app/templates/**/*.html"]`
in order to automatically find files in subdirectories (may be useful for organization in larger projects).
