### PR TITLE
Oops - I forgot to update the lint task path on the last commit

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -5,7 +5,7 @@
 config.init({
 
   lint: {
-    files: ["build/config.js", "app/modules/**/*.js"]
+    files: ["build/config.js", "app/**/*.js"]
   },
 
   concat: {


### PR DESCRIPTION
Changed the lint path for app from:
`app/modules/*.js`
to:
`app/modules/**/*.js`
To make sure .js files in subdirectories are linted as part of the build process. Missed that in the last [pull request](https://github.com/tbranyen/backbone-boilerplate/commit/3678897e8ab0a051b64264832c8da5e8a6c79d51).
