### PR TITLE
Use the AMD versions of backbone and underscore.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -12,19 +12,6 @@ require.config({
     jquery: "../assets/js/libs/jquery",
     underscore: "../assets/js/libs/underscore",
     backbone: "../assets/js/libs/backbone",
-
-    // Shim Plugin
-    use: "../assets/js/plugins/use"
-  },
-
-  use: {
-    backbone: {
-      deps: ["use!underscore", "jquery"],
-      attach: "Backbone"
-    },
-
-    underscore: {
-      attach: "_"
-    }
   }
+
 });

--- a/app/main.js
+++ b/app/main.js
@@ -3,7 +3,7 @@ require([
 
   // Libs
   "jquery",
-  "use!backbone",
+  "backbone",
 
   // Modules
   "modules/example"

--- a/app/modules/example.js
+++ b/app/modules/example.js
@@ -2,7 +2,7 @@ define([
   "namespace",
 
   // Libs
-  "use!backbone"
+  "backbone"
 
   // Modules
 

--- a/app/namespace.js
+++ b/app/namespace.js
@@ -1,8 +1,8 @@
 define([
   // Libs
   "jquery",
-  "use!underscore",
-  "use!backbone"
+  "underscore",
+  "backbone"
 ],
 
 function($, _, Backbone) {

--- a/assets/js/libs/backbone.js
+++ b/assets/js/libs/backbone.js
@@ -5,14 +5,25 @@
 //     For all details and documentation:
 //     http://backbonejs.org
 
-(function(){
-
+(function(root, factory) {
+  // Set up Backbone appropriately for the environment.
+  if (typeof exports !== 'undefined') {
+    // Node/CommonJS, no need for jQuery in that case.
+    factory(root, exports, require('underscore'));
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
+      // Export global even in AMD case in case this script is loaded with
+      // others that may still expect a global Backbone.
+      root.Backbone = factory(root, exports, _, $);
+    });
+  } else {
+    // Browser globals
+    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender));
+  }
+}(this, function(root, Backbone, _, $) {
   // Initial Setup
   // -------------
-
-  // Save a reference to the global object (`window` in the browser, `global`
-  // on the server).
-  var root = this;
 
   // Save the previous value of the `Backbone` variable, so that it can be
   // restored later on, if `noConflict` is used.
@@ -22,24 +33,8 @@
   var slice = Array.prototype.slice;
   var splice = Array.prototype.splice;
 
-  // The top-level namespace. All public Backbone classes and modules will
-  // be attached to this. Exported for both CommonJS and the browser.
-  var Backbone;
-  if (typeof exports !== 'undefined') {
-    Backbone = exports;
-  } else {
-    Backbone = root.Backbone = {};
-  }
-
   // Current version of the library. Keep in sync with `package.json`.
   Backbone.VERSION = '0.9.1';
-
-  // Require Underscore, if we're on the server, and it's not already present.
-  var _ = root._;
-  if (!_ && (typeof require !== 'undefined')) _ = require('underscore');
-
-  // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
-  var $ = root.jQuery || root.Zepto || root.ender;
 
   // Set the JavaScript library that will be used for DOM manipulation and
   // Ajax calls (a.k.a. the `$` variable). By default Backbone will use: jQuery,
@@ -54,7 +49,7 @@
   // to its previous owner. Returns a reference to this Backbone object.
   Backbone.noConflict = function() {
     root.Backbone = previousBackbone;
-    return this;
+    return Backbone;
   };
 
   // Turn on `emulateHTTP` to support legacy HTTP servers. Setting this option
@@ -1287,4 +1282,5 @@
     throw new Error('A "url" property or function must be specified');
   };
 
-}).call(this);
+  return Backbone;
+}));

--- a/assets/js/libs/underscore.js
+++ b/assets/js/libs/underscore.js
@@ -48,10 +48,11 @@
   // Create a safe reference to the Underscore object for use below.
   var _ = function(obj) { return new wrapper(obj); };
 
-  // Export the Underscore object for **Node.js**, with
-  // backwards-compatibility for the old `require()` API. If we're in
-  // the browser, add `_` as a global object via a string identifier,
-  // for Closure Compiler "advanced" mode.
+  // Export the Underscore object for **Node.js** and **"CommonJS"**, with
+  // backwards-compatibility for the old `require()` API. If we're not in
+  // CommonJS, add `_` to the global object via a string identifier for
+  // the Closure Compiler "advanced" mode. Registration as an AMD module
+  // via define() happens at the end of this file.
   if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = _;
@@ -995,5 +996,13 @@
   wrapper.prototype.value = function() {
     return this._wrapped;
   };
+
+  // AMD define happens at the end for compatibility with AMD loaders
+  // that don't enforce next-turn semantics on modules.
+  if (typeof define === 'function' && define.amd) {
+    define('underscore', function() {
+      return _;
+    });
+  }
 
 }).call(this);


### PR DESCRIPTION
I like the move towards AMD. Now that you've merged the AMD branch into master, I think it makes sense to also use the AMD versions of backbone and underscore (from https://github.com/amdjs).
