### PR TITLE
Fixed a problem in the fetchTemplate jQuery.get() method.

### DIFF
--- a/app/namespace.js
+++ b/app/namespace.js
@@ -22,13 +22,13 @@ function($, _, Backbone) {
         return done(JST[path]);
       }
 
-      // Fetch it asynchronously if not available from JST
+      // Fetch it asynchronously if not available from JST 
       return $.get(path, function(contents) {
         var tmpl = _.template(contents);
 
         // Set the global JST cache and return the template
         done(JST[path] = tmpl);
-      });
+      }, "text");
     },
 
     // Create a custom object with a nested Views object


### PR DESCRIPTION
This will ensure that the results of the jQuery.get() method come back as plain text. If you don't set this, the results of a simple layout with nothing but a block level element will return as a Document Object.
