### PR TITLE
Setting the host to 0.0.0.0 still works with localhost, but also allows ...

### DIFF
--- a/build/tasks/server/index.js
+++ b/build/tasks/server/index.js
@@ -15,7 +15,7 @@ task.registerTask("server", "Run development server.", function(prop) {
     index: "./index.html",
 
     port: 8000,
-    host: "127.0.0.1"
+    host: "0.0.0.0"
   });
 
   options.folders = options.folders || {};


### PR DESCRIPTION
...the server to listen on network-accessible IP's automatically.
