### PR TITLE
pull config from current directory regardless of path index is called fr...

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -5,11 +5,11 @@ var grunt = require("grunt");
 var taskList = fs.readdirSync(__dirname + "/tasks").filter(function(task) {
   return fs.statSync(__dirname + "/tasks/" + task).isDirectory();
 }).map(function(task) {
-  return "build/tasks/" + task;
-}).concat("build/tasks");
+  return __dirname + "/tasks/" + task;
+}).concat(__dirname + "/tasks");
 
 grunt.cli({
-  base: __dirname+"/../",
+  base: __dirname + "/../",
   config: __dirname + "/config.js",
   tasks: taskList
 }, function() {});


### PR DESCRIPTION
I'm using forman to spin up my api (sinatra) and my ui (backbone) at the same time. without this fix, grunt can't find config.js.
