### PR TITLE
Amend links in example page

### DIFF
--- a/app/templates/example.html
+++ b/app/templates/example.html
@@ -76,12 +76,12 @@
   <h2 id="getting-help">Getting help</h2>
 
   <p>If you're encountering issues, need assistance, or have a question that hasn't been answered in this
-  tutorial or <a target="blank" href="https://github.com/tbranyen/backbone-boilerplate">the GitHub project page</a>
+  tutorial or <a target="blank" href="https://github.com/backbone-boilerplate/backbone-boilerplate">the GitHub project page</a>
   you may find help in one of these places:</p>
 
   <ul>
     <li>IRC - #documentcloud on irc.freenode.net
-    <li><a target="blank" href="http://github.com/tbranyen/backbone-boilerplate/issues">GitHub Issues</a> - Please report if you've found an issue,
+    <li><a target="blank" href="https://github.com/backbone-boilerplate/backbone-boilerplate/issues">GitHub Issues</a> - Please report if you've found an issue,
     bug, or controversial request.
   </ul>
 
@@ -267,7 +267,7 @@
   </p>
 
   <h3 id="events">Working with Application Wide Events</h3>
-  <p>Application wide events provide a convenient way for modules to communicate with each other. <code>namespace.app</code> references a copy of the Backbone.Events object. <a href="http://documentcloud.github.com/backbone/#Events">More information on Backbone Events</a></p>
+  <p>Application wide events provide a convenient way for modules to communicate with each other. <code>namespace.app</code> references a copy of the Backbone.Events object. <a href="http://documentcloud.github.com/backbone/#Events" target="_blank">More information on Backbone Events</a></p>
 
   <p>
   To bind a callback function to an event:
@@ -380,7 +380,7 @@ the settings.</p>
   <h2>Useful resources</h2>
 
   <ul>
-    <li><a href="http://backbonejs.org/">Backbone documentation</a> - Framework on which Backbone Boilerplate is built.
-    <li><a href="http://documentcloud.github.com/underscore/docs/underscore.html">Underscore documentation</a> - Required dependency for Backbone.
+    <li><a href="http://backbonejs.org/" target="_blank">Backbone documentation</a> - Framework on which Backbone Boilerplate is built.
+    <li><a href="http://documentcloud.github.com/underscore/docs/underscore.html" target="_blank">Underscore documentation</a> - Required dependency for Backbone.
   </ul>
 </section>


### PR DESCRIPTION
Amend links in example page to https://github.com/backbone-boilerplate/backbone-boilerplate - currently 404 and amend external links to open in new page - makes them consistent // example.html template
