### PR TITLE
Improved $.ajax options for fetchTemplate()

### DIFF
--- a/app/namespace.js
+++ b/app/namespace.js
@@ -28,17 +28,29 @@ function($, _, Backbone) {
       }
 
       // Fetch it asynchronously if not available from JST 
-      $.get(path, function(contents) {
-        JST[path] = _.template(contents);
+      $.ajax({
+        url: path,
 
-        // Set the global JST cache and return the template
-        if (_.isFunction(done)) {
-          done(JST[path]);
+        type: "get",
+
+        dataType: "text",
+        // make sure that template requests are never cached
+        cache: false,
+        // prevent global ajax event handlers from firing
+        global: false,
+
+        success: function(contents) {
+          JST[path] = _.template(contents);
+
+          // Set the global JST cache and return the template
+          if (_.isFunction(done)) {
+            done(JST[path]);
+          }
+
+          // Resolve the template deferred
+          def.resolve(JST[path]);
         }
-
-        // Resolve the template deferred
-        def.resolve(JST[path]);
-      }, "text");
+      });
 
       // Ensure a normalized return value (Promise)
       return def.promise();


### PR DESCRIPTION
This initially came about after running into caching issues when using a server other than what's provided by `bbb server`.

The solution was to change `$.get` to `$.ajax` and set `cache: false` to disable any template caching. Additionally, `global: false` is set to prevent any global ajax handlers from firing when loading templates. The reasoning being that in production you should always be running the release task and pre-compiling your templates, in which case there would normally be no ajax events trigger as a result of template loading.

I feel like these two additions make for a more reasonable set of defaults for async template loading--but in any case I think `$.ajax` should be preferred over `$.get` so that adding your own options is slightly easier.

Curious to hear your thoughts on this...

Thanks!
