### PR TITLE
Suggestion to fix #104 

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -40,6 +40,23 @@ module.exports = function(grunt) {
         "app/templates/**/*.html"
       ]
     },
+    
+    // The handlebars task compiles all application templates into JavaScript
+    // functions using Handlebars templating engine. You will need to install
+    // grunt-handlebars globally in order to run this task.
+    //
+    // Since this task defaults to writing to the same file as the jst task,
+    // edit the task or avoid using the two at the same time.
+    //
+    // The concat task depends on this file to exist, so if you decide to
+    // remove this, ensure concat is updated accordingly.
+    handlebars: {
+      all: {
+        src: "app/templates",
+        dest: "dist/debug/templates.js"
+      }
+    },
+
 
     // The concatenate task is used here to merge the almond require/define
     // shim and the templates into the application code.  It's named


### PR DESCRIPTION
Adding Handlebars support stub. Depends on grunt-handlebars being installed globally.
Probably needs to point the user to edit the default task.
