### PR TITLE
Simplification using .html()

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -67,7 +67,7 @@ function($, _, Backbone) {
       });
 
       // Insert into the DOM.
-      $("#main").empty().append(layout.el);
+      $("#main").html(layout.el);
 
       // Render the layout.
       layout.render();


### PR DESCRIPTION
I read your blog post (http://tbranyen.com/post/missing-jquery-events-while-rendering) where you mention jQuery `.html()` vs. `.empty().append()`.

Since the solution to your problem really had nothign to do with that but rather needing to call .detach(), seems like reverting back to simpler .html() is fine.

Especially when you look at the jQuery source for .html() which does the same thing: https://github.com/jquery/jquery/blob/master/src/manipulation.js#L250
