### PR TITLE
Increase hyperlink selector specificity

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -19,14 +19,14 @@ function(app, Router) {
   // All navigation that is relative should be passed through the navigate
   // method, to be processed by the router. If the link has a `data-bypass`
   // attribute, bypass the delegation completely.
-  $(document).on("click", "a:not([data-bypass])", function(evt) {
+  $(document).on("click", "a[href]:not([data-bypass])", function(evt) {
     // Get the absolute anchor href.
     var href = { prop: $(this).prop("href"), attr: $(this).attr("href") };
     // Get the absolute root.
     var root = location.protocol + "//" + location.host + app.root;
 
     // Ensure the root is part of the anchor href, meaning it's relative.
-    if (href.prop && href.prop.slice(0, root.length) === root) {
+    if (href.prop.slice(0, root.length) === root) {
       // Stop the default event to ensure the link will not cause a page
       // refresh.
       evt.preventDefault();


### PR DESCRIPTION
Delegating on a more specific selector makes this operation slightly
more efficient. Anchor tags without an "href" property are not
considered for overriding, precluding the need to wrap them in a jQuery
object.
