### PR TITLE
Name in package.json doesn't follow CommonJS spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Backbone Boilerplate",
+  "name": "backbone-boilerplate",
   "version": "0.1.0",
 
   "jam": {


### PR DESCRIPTION
The name in package.json needs to be lowercase and stripped of whitespace to meet the CommonJS Spec. Noticed this when adding an npm dependency and it gave me an error.
