### PR TITLE
Update test to prevent asynchronous config from breaking test

### DIFF
--- a/test/jasmine/index.html
+++ b/test/jasmine/index.html
@@ -17,14 +17,22 @@
   <script src="vendor/jasmine-html.js"></script>
 
   <!-- Load application -->
-  <script data-main="../../app/config"
-    src="../../vendor/jam/require.js"></script>
+  <script>
+    // Ensure you point to where your tests are, base directory is app/, which
+    // is why ../test is necessary
+    require.config({
+      baseUrl : '../../app',
+      paths   : { spec: "../test/jasmine/spec" }
+    });
+  </script>
+  <script src="../../vendor/jam/require.js"></script>
+  <script src="../../app/config.js"></script>
 
   <!-- Declare your spec files to be run here -->
   <script>
     // Ensure you point to where your spec folder is, base directory is app/,
     // which is why ../test is necessary
-    require({ paths: { spec: "../test/jasmine/spec" } }, [
+    require([
 
       // Load the example spec, replace this and add your own spec
       "spec/example.spec"

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -24,14 +24,20 @@
   <script src="vendor/qunit.js"></script>
 
   <!-- Load application -->
-  <script data-main="../../app/config"
-    src="../../vendor/jam/require.js"></script>
-
-  <!-- Declare your test files to be run here -->
   <script>
     // Ensure you point to where your tests are, base directory is app/, which
     // is why ../test is necessary
-    require({ paths: { tests: "../test/qunit/tests" } }, [
+    require.config({
+      baseUrl : '../../app',
+      paths   : { tests: "../test/qunit/tests" }
+    });
+  </script>
+  <script src="../../vendor/jam/require.js"></script>
+  <script src="../../app/config.js"></script>
+
+  <!-- Declare your test files to be run here -->
+  <script>
+    require([
 
       // Load the example tests, replace this and add your own tests
       "tests/example"


### PR DESCRIPTION
Previously, it was possible that the test started before the `config.js` file was loaded. This could create bugs as some shim config and paths config could break modules definitions. Now, the config is always loaded.

I had to declare `require.config` before adding the config script tag to make sure the baseUrl is set correctly for the `deps` array to work.
