### PR TITLE
Fixes #194

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -39,7 +39,7 @@ function() {
       // Seek out the template asynchronously.
       $.get(app.root + path, function(contents) {
         done(JST[path] = _.template(contents));
-      });
+      }, 'html');
     }
   });
 


### PR DESCRIPTION
As per #194, this ensures templates are returned as HTML strings.
