### PR TITLE
Add dependencies to run Karma, and remove karma-requirejs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,7 +191,6 @@ module.exports = function(grunt) {
           "karma-jasmine",
           "karma-mocha",
           "karma-qunit",
-          "karma-requirejs",
           "karma-chrome-launcher",
           "karma-firefox-launcher",
           "karma-phantomjs-launcher"
@@ -267,7 +266,7 @@ module.exports = function(grunt) {
   grunt.registerTask("release", ["debug", "uglify", "mincss"]);
 
   // The test task take care of starting test server and running tests.
-  grunt.registerTask("test", ["jshint", "server:test", "karma:mocha"]);
+  grunt.registerTask("test", ["jshint", "server:test", "karma"]);
 
   // When running the default Grunt command, just lint the code.
   grunt.registerTask("default", ["jshint"]);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "grunt-karma-0.9.1": "0.4.3",
     "karma-jasmine": "~0.0.1",
     "karma-mocha": "~0.0.1",
-    "karma-qunit": "~0.0.1"
+    "karma-qunit": "~0.0.1",
+    "karma-phantomjs-launcher": "~0.0.1",
+    "karma-chrome-launcher": "~0.0.1",
+    "karma-firefox-launcher": "~0.0.1"
   },
 
   "jam": {


### PR DESCRIPTION
Got karma to run on windows - finally seems like the trouble was the karma-requirejs plugin as @tbranyen said.

Just fixed dependencies so it can be run as-is without missing deps.
