### PR TITLE
Update requirejs grunt task config.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,16 +52,17 @@ module.exports = function(grunt) {
           out: "<%= dist.debug %>source.js",
 
           // Root application module.
-          name: "config",
+          name: "main",
 
-          // Include the main application.
-          insertRequire: ["main"],
+          // Include nested `require` by default. Use `exclude` if you're loading
+          // some dynamic/runtime files.
+          findNestedDependencies: true,
 
-          // This will ensure the application runs after being built.
-          include: ["app", "main", "router"],
-
-          // Wrap everything in an IIFE.
-          wrap: true
+          wrap: {
+            // set baseUrl config if concat is used
+            start: "require.config({ baseUrl: 'app/', waitSeconds: 30 });",
+            end: " "
+          }
         }
       }
     },


### PR DESCRIPTION
I find that this way of building with Rjs is less error prompt as we'll walk dependencies automatically from the `main` module without any need for us to included some manually inside the `include` option.

Also, using wrap, we can add some extra configs so that when using the builded files (if served from a different directory) we can still require excluded modules - that's mostly a safety net so the builded file will run in the same context as the development app.

In the wrap, we also use a higher default timeout for modules so we're sure slow connection won't fail because it didn't have the time in 7sec (the default) to load a dependencies. 30sec for a production app seems more reasonable (may even be better if higher).
