### PR TITLE
Use load-grunt-tasks module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,21 +183,8 @@ module.exports = function(grunt) {
     }
   });
 
-  // Grunt contribution tasks.
-  grunt.loadNpmTasks("grunt-contrib-clean");
-  grunt.loadNpmTasks("grunt-contrib-jshint");
-  grunt.loadNpmTasks("grunt-contrib-cssmin");
-  grunt.loadNpmTasks("grunt-contrib-copy");
-  grunt.loadNpmTasks("grunt-contrib-compress");
-
-  // Third-party tasks.
-  grunt.loadNpmTasks("grunt-karma");
-  grunt.loadNpmTasks("grunt-processhtml");
-
-  // Grunt BBB tasks.
-  grunt.loadNpmTasks("grunt-bbb-server");
-  grunt.loadNpmTasks("grunt-bbb-requirejs");
-  grunt.loadNpmTasks("grunt-bbb-styles");
+  // Load Grunt plugins (every node module prefixed with `grunt-`)
+  require("load-grunt-tasks")(grunt);
 
   // When running the default Grunt command, just lint the code.
   grunt.registerTask("default", [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-contrib-compress": "~0.5.2",
     "grunt-processhtml": "~0.1.0",
     "grunt-karma": "~0.6.2",
+    "load-grunt-tasks": "~0.1.0",
     "karma-jasmine": "~0.1.0",
     "karma-mocha": "~0.1.0",
     "karma-qunit": "~0.1.0",


### PR DESCRIPTION
This simplify the Grunt tasks loading a lot and keep the Gruntfile more tidy.

Also, that'd be great for generator-BBB as it'd make it easier to bundle extra Grunt plugins (like coffeescript, etc).
