### PR TITLE
bower nests jquery in a 'dist' folder, initial grunt build fails

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -5,7 +5,7 @@ require.config({
     "vendor": "../vendor",
     "almond": "../vendor/bower/almond/almond",
     "underscore": "../vendor/bower/lodash/dist/lodash.underscore",
-    "jquery": "../vendor/bower/jquery/jquery",
+    "jquery": "../vendor/bower/jquery/dist/jquery",
     "backbone": "../vendor/bower/backbone/backbone"
   }
 });


### PR DESCRIPTION
On a plain vanilla install (after `npm install`, `bower install`, and during the initial run of `grunt`), the requirejs grunt task produces an error:

```
Running "requirejs:release" (requirejs) task
Error: ENOENT, no such file or directory '~/backbone-boilerplate/dist/vendor/bower/jquery/jquery.js'
```

...because inside the vendor directory, jquery.js is nested in a `dist` directory.
