### PR TITLE
Change vendor to bower_components. Fixes #258

### DIFF
--- a/build/tasks/copy.coffee
+++ b/build/tasks/copy.coffee
@@ -1,9 +1,9 @@
 module.exports = ->
   @loadNpmTasks "grunt-contrib-copy"
 
-  # Move vendor and app logic during a build.
+  # Move bower_components and app logic during a build.
   @config "copy",
     release:
       files: [
-        src: "vendor/**", dest: "dist/"
+        src: "bower_components/**", dest: "dist/"
       ]


### PR DESCRIPTION
Bower now installs to bower_components. Fixes issue#258

Signed-off-by: Dave Phipps david.phipps@chapel-studios.co.uk
